### PR TITLE
Add True/False Singletons to List

### DIFF
--- a/src/bgpython_part_A0300_valref.md
+++ b/src/bgpython_part_A0300_valref.md
@@ -234,6 +234,7 @@ They are:
 * Integers between -5 and 256 inclusive.
 * Strings that contain only letters, numbers, or underscores.
 * The `None` object.
+* The `True` and `False` objects.
 
 This is why `"Beej!"` isn't interned (because it contains punctuation),
 and why `"Alice"` _is_ interned.


### PR DESCRIPTION
Adding the `True` and `False` objects to the list of singleton objects in Appendix C.

A fun little bit of code to run in REPL:
```
>>> id(True)
94208502894096
>>> True = 2
>>> id(True)
94208522194112
>>> True = (1 == 1)
>>> id(True)
94208502894096
```